### PR TITLE
feat: Extract user's name from raw info

### DIFF
--- a/lib/omniauth/strategies/procore.rb
+++ b/lib/omniauth/strategies/procore.rb
@@ -16,6 +16,7 @@ module OmniAuth
       info do
         {
           email: raw_info['login'],
+          name: raw_info['name'],
           procore_id: raw_info['id']
         }
       end


### PR DESCRIPTION
The `/vapid/me` endpoint now returns the user's name as part of the 
response. Let's expose that to consumers of this gem

https://developers.procore.com/reference/me