### PR TITLE
Override the callback_url in the procore strategy

### DIFF
--- a/lib/omniauth/strategies/procore.rb
+++ b/lib/omniauth/strategies/procore.rb
@@ -24,6 +24,10 @@ module OmniAuth
       def raw_info
         @raw_info ||= access_token.get('/vapid/me').parsed
       end
+
+      def callback_url
+        full_host + script_name + callback_path
+      end
     end
   end
 end


### PR DESCRIPTION
OmniAuth 1.4.0 deleted the override of callback_url from
OmniAuth::Strategies::OAuth2.

See https://github.com/omniauth/omniauth-oauth2/commit/26152673224aca5c3e918bcc83075dbb0659717f and https://github.com/omniauth/omniauth-oauth2/issues/81

This causes an invalid grant error due to a uri mismatch.