### PR TITLE
Fix /vapid/me call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 /*.gem
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.5.1 (October 29, 2018)
+
+* Fix call to /vapid/me to use a separate api domain (e.g. api.procore.com)
+ if it is different to the auth domain (e.g. login.procore.com).
+
+  *David Hayward*
+
+
 ## 0.5.0 (October 17, 2018)
 
 * Change default site to login.procore.com (from app.procore.com)

--- a/lib/omniauth/procore/version.rb
+++ b/lib/omniauth/procore/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Procore
-    VERSION = "0.5.0"
+    VERSION = "0.5.1"
   end
 end

--- a/lib/omniauth/strategies/procore.rb
+++ b/lib/omniauth/strategies/procore.rb
@@ -6,8 +6,9 @@ module OmniAuth
       option :name, 'procore'
 
       option :client_options,
-        site: 'https://login.procore.com',
-        authorize_path: '/oauth/authorize'
+             site: 'https://login.procore.com',
+             api_site: 'https://api.procore.com',
+             authorize_path: '/oauth/authorize'
 
       uid do
         raw_info['id']
@@ -22,12 +23,40 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('/vapid/me').parsed
+        @raw_info ||=
+          if options.client_options.site == options.client_options.api_site
+            # This is the sandbox case where we use sandbox.procore.com
+            # for both authentication and the api
+            access_token.get('/vapid/me').parsed
+          else
+            # This is the production case where we have separate subdomains
+            # for authentication and for the api
+            api_get('/vapid/me')
+          end
       end
 
       def callback_url
         full_host + script_name + callback_path
       end
+
+      private
+
+      # @param [String] path of the api endpoint
+      # @return [Hash] the response json body parsed into a hash
+      def api_get(path)
+        uri = URI.parse("#{options.client_options.api_site}#{path}")
+        request = Net::HTTP::Get.new(uri)
+        request["authorization"] = "Bearer #{access_token.token}"
+        response = Net::HTTP.start(request.uri.hostname, request.uri.port, use_ssl: true) do |http|
+          http.request(request)
+        end
+        if response.kind_of? Net::HTTPSuccess
+          JSON.parse(response.body)
+        else
+          raise "Error talking to Procore: #{response.message} (code = #{response.code}, uri = #{response.uri})"
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
With the change to have separate Procore auth and api domains, the call to /vapid/me was failing in the production environment because it was going to the auth domain. With this commit we add the api_site client option, and use it if it is different to the default (auth) site option.