### PR TITLE
fix: Fetching user details

### DIFF
--- a/lib/omniauth/strategies/procore.rb
+++ b/lib/omniauth/strategies/procore.rb
@@ -7,6 +7,7 @@ module OmniAuth
 
       option :client_options,
         site: 'https://login.procore.com',
+        api_site: 'https://api.procore.com',
         authorize_path: '/oauth/authorize'
 
       uid do
@@ -22,6 +23,7 @@ module OmniAuth
       end
 
       def raw_info
+        access_token.client.site = options[:client_options][:api_site]
         @raw_info ||= access_token.get('/vapid/me').parsed
       end
 


### PR DESCRIPTION
Fixes: https://github.com/procore/omniauth-procore/issues/5, introduced in https://github.com/procore/omniauth-procore/pull/3 (my fault!)

Corrects an error when fetching user information. We moved the
authentication endpoint to login.procore.com, however that incorrectly
handles the /vapid/me endpoint.

To fix, added an additonal option to the gem: `api_site`. This defaults
to the API gateway, api.procore.com which will correctly handle routing
/vapid/me.

Should the end user want to change either value (for usage with
sandboxes, for example), this will still support configuring the gem for
that purpose.

The configuration could look something like this:

```ruby
  use OmniAuth::Builder do
    provider(
      :procore,
      ENV['PROCORE_KEY'],
      ENV['PROCORE_SECRET'],
      client_options: {
        site: ENV.fetch('PROCORE_AUTH_URL', 'https://login.procore.com'),
        api_site: ENV.fetch('PROCORE_API_URL', 'https://api.procore.com')
      }
    )
  end
```