### PR TITLE
[ZL-873] Update Omniauth to support versioning and improve readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.7.0 (March 1, 2021)
+
+* Add API :version option. Defaults to v1.0.
+
+  PR #8 - https://github.com/procore/omniauth-procore/pull/8
+
+  *Nate Baer*
+
 ## 0.6.0 (November 9, 2018)
 
 * Fix fetching user details, add :app_site client option

--- a/README.md
+++ b/README.md
@@ -23,8 +23,20 @@ Or install it yourself as:
 ## Usage
 
 ```ruby
-use OmniAuth::Builder do
+Rails.application.config.middleware.use OmniAuth::Builder do
   provider :procore, ENV['PROCORE_KEY'], ENV['PROCORE_SECRET']
+end
+```
+
+With a different Procore environment (e.g. sandbox):
+
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :procore, ENV['PROCORE_KEY'], ENV['PROCORE_SECRET'],
+  client_options: {
+    site: 'https://sandbox.procore.com',
+    api_site: 'https://sandbox.procore.com',
+  },
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,20 +24,26 @@ Or install it yourself as:
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :procore, ENV['PROCORE_KEY'], ENV['PROCORE_SECRET']
+  provider :procore, ENV['PROCORE_KEY'], ENV['PROCORE_SECRET'], 
+  client_options: {} # Optional
 end
 ```
 
-With a different Procore environment (e.g. sandbox):
+To specify a different Procore environment (e.g. sandbox):
 
 ```ruby
-Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :procore, ENV['PROCORE_KEY'], ENV['PROCORE_SECRET'],
-  client_options: {
-    site: 'https://sandbox.procore.com',
-    api_site: 'https://sandbox.procore.com',
-  },
-end
+client_options: {
+  site: 'https://sandbox.procore.com',
+  api_site: 'https://sandbox.procore.com',
+}
+```
+
+Procore API version `v1.0` is used by default to request user information. It is not recommended to change this, but it can be set to support the legacy API `vapid` and possible future versions (e.g. `v2.0`).
+
+```ruby
+client_options: {
+  version: `vapid`
+}
 ```
 
 ## Development

--- a/lib/omniauth/procore/version.rb
+++ b/lib/omniauth/procore/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Procore
-    VERSION = "0.6.0"
+    VERSION = "0.7.0"
   end
 end

--- a/lib/omniauth/strategies/procore.rb
+++ b/lib/omniauth/strategies/procore.rb
@@ -5,10 +5,13 @@ module OmniAuth
     class Procore < OmniAuth::Strategies::OAuth2
       option :name, 'procore'
 
-      option :client_options,
+      option(
+        :client_options,
         site: 'https://login.procore.com',
         api_site: 'https://api.procore.com',
-        authorize_path: '/oauth/authorize'
+        authorize_path: '/oauth/authorize',
+        version: 'v1.0'
+      )
 
       uid do
         raw_info['id']
@@ -24,7 +27,9 @@ module OmniAuth
 
       def raw_info
         access_token.client.site = options[:client_options][:api_site]
-        @raw_info ||= access_token.get('/vapid/me').parsed
+        version = options[:client_options][:version]
+        path = /\Av\d+\.\d+\z/.match?(version) ? "/rest/#{version}" : "/#{version}"
+        @raw_info ||= access_token.get("#{path}/me").parsed
       end
 
       def callback_url


### PR DESCRIPTION
Ticket: [ZL-873](https://procoretech.atlassian.net/browse/ZL-873)

- Allows a configurable API version for fetching user information that defaults to `v1.0`.
- Add documentation on how to specify a different base URL than production (eg. sandbox)

# Testing Notes
- [x] Create sample app that uses the Ruby SDK with Procore Omniauth configured
- [x] Authorize Procore application with Omniauth
- [x] Confirm request was made to `/rest/v1.0/me`